### PR TITLE
Neukeeper: Upgrade Serilog to 3.1.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="Serilog" Version="3.1.0" />
+    <PackageVersion Include="Serilog" Version="3.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This upgrades the following packages:

| Project | Package | Old Version | New Version |
| - | - | - | - |
| ProjectC | Serilog | 3.1.0 | 3.1.1 |

Central package management is used ✔️
