### PR TITLE
Neukeeper: Upgrade Newtonsoft.Json to 13.0.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Serilog" Version="3.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This upgrades the following packages:

| Project | Package | Old Version | New Version |
| - | - | - | - |
| ProjectB | Newtonsoft.Json | 13.0.2 | 13.0.3 |
| ProjectA | Newtonsoft.Json | 13.0.2 | 13.0.3 |

Central package management is used ✔️
