### PR TITLE
Neukeeper: Upgrade 2 packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="Serilog" Version="3.1.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Serilog" Version="3.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This upgrades the following packages:

| Project | Package | Old Version | New Version |
| - | - | - | - |
| ProjectB | Serilog | 3.1.0 | 3.1.1 |
| ProjectC | Serilog | 3.1.0 | 3.1.1 |
| ProjectC | Serilog | 3.1.0 | 3.1.1 |
| ProjectC | Serilog | 3.1.0 | 3.1.1 |
| ProjectA | Serilog | 3.1.0 | 3.1.1 |
| ProjectB | Newtonsoft.Json | 13.0.2 | 13.0.3 |
| ProjectA | Newtonsoft.Json | 13.0.2 | 13.0.3 |

Central package management is used ✔️
